### PR TITLE
Add Qt 6.4 builds

### DIFF
--- a/.github/workflows/QtApng.yml
+++ b/.github/workflows/QtApng.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [ master ]
   workflow_dispatch:
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:
@@ -53,6 +55,7 @@ jobs:
           filename: "qtapng-${{ matrix.os }}-${{ matrix.vers }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}.zip"
 
       - name: 'Upload to continous release'
+        if: github.event_name != 'pull_request'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: 'cont'

--- a/.github/workflows/QtApng.yml
+++ b/.github/workflows/QtApng.yml
@@ -26,11 +26,11 @@ jobs:
             vers: '6.2.2'
             forceWin32: 'false'
           - os: windows-2019
-            vers: '6.5.0'
+            vers: '6.4.3'
             forceWin32: 'false'
             arch: 'win64_msvc2019_64'
           - os: macos-latest
-            vers: '6.5.0'
+            vers: '6.4.3'
             forceWin32: 'false'
 
     steps:

--- a/.github/workflows/QtApng.yml
+++ b/.github/workflows/QtApng.yml
@@ -23,6 +23,13 @@ jobs:
           - os: macos-latest
             vers: '6.2.2'
             forceWin32: 'false'
+          - os: windows-2019
+            vers: '6.5.0'
+            forceWin32: 'false'
+            arch: 'win64_msvc2019_64'
+          - os: macos-latest
+            vers: '6.5.0'
+            forceWin32: 'false'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [ master ]
   workflow_dispatch:
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -65,6 +65,7 @@ jobs:
           filename: "kimageformats-${{ matrix.os }}-${{ matrix.vers }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}.zip"
 
       - name: 'Upload to continous release'
+        if: github.event_name != 'pull_request'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: 'cont'

--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -25,6 +25,13 @@ jobs:
           - os: macos-latest
             vers: '6.2.2'
             universalBinary: 'true'
+          - os: windows-2019
+            vers: '6.5.0'
+            forceWin32: 'false'
+            arch: 'win64_msvc2019_64'
+          - os: macos-latest
+            vers: '6.5.0'
+            universalBinary: 'true'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -1,16 +1,16 @@
 name: Build KImageFormats
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix: 
+      matrix:
         include:
           - os: ubuntu-20.04
             vers: '5.15.2'
@@ -28,11 +28,11 @@ jobs:
             vers: '6.2.2'
             universalBinary: 'true'
           - os: windows-2019
-            vers: '6.5.0'
+            vers: '6.4.3'
             forceWin32: 'false'
             arch: 'win64_msvc2019_64'
           - os: macos-latest
-            vers: '6.5.0'
+            vers: '6.4.3'
             universalBinary: 'true'
 
     steps:
@@ -69,4 +69,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: 'cont'
-          files:  kimageformats-*.zip
+          files: kimageformats-*.zip


### PR DESCRIPTION
Thank you for the builds! I want to use the macOS artifacts for https://github.com/SevenTV/chatterino7/pull/245. We're currently on Qt 5.15.2 and Qt 6.5.0, so I'm adding a build for the 6.5.0 version. With 6.6 being around the corner, maybe a build for that version should be added as well if it's not binary compatible to 6.5/6.4.