### PR TITLE
Windows: Workaround for crashing with older Visual C++ runtimes

### DIFF
--- a/pwsh/buildapng.ps1
+++ b/pwsh/buildapng.ps1
@@ -15,6 +15,10 @@ if ($IsWindows) {
     }
     & "$env:GITHUB_WORKSPACE/pwsh/vcvars.ps1"
     choco install ninja pkgconfiglite
+
+    # Workaround for https://developercommunity.visualstudio.com/t/10664660
+    $env:CXXFLAGS += " -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"
+    $env:CFLAGS += " -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"
 } elseif ($IsMacOS) {
     brew update
     brew install ninja

--- a/pwsh/buildkimageformats.ps1
+++ b/pwsh/buildkimageformats.ps1
@@ -21,6 +21,10 @@ if ($IsWindows) {
     }
     & "$env:GITHUB_WORKSPACE/pwsh/vcvars.ps1"
     choco install ninja pkgconfiglite
+
+    # Workaround for https://developercommunity.visualstudio.com/t/10664660
+    $env:CXXFLAGS += " -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"
+    $env:CFLAGS += " -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"
 } elseif ($IsMacOS) {
     brew update
     brew install ninja

--- a/pwsh/get-vcpkg-deps.ps1
+++ b/pwsh/get-vcpkg-deps.ps1
@@ -26,18 +26,20 @@ if ($IsWindows) {
     sudo apt-get install nasm libxi-dev libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev
 }
 
-# Set up prefixes
+# Set default triplet
 if ($IsWindows) {
-    & "$env:GITHUB_WORKSPACE\pwsh\vcvars.ps1"
-
     # Use environment variable to detect target platform
     $env:VCPKG_DEFAULT_TRIPLET =
         $env:buildArch -eq 'X86' ? 'x86-windows' :
         $env:buildArch -eq 'Arm64' ? 'arm64-windows' :
         'x64-windows'
 } elseif ($IsMacOS) {
-    # Makes things more reproducible for testing on M1 machines
+    # Build x64 first; arm64 will come later for universal binaries
     $env:VCPKG_DEFAULT_TRIPLET = "x64-osx"
+} elseif ($IsLinux) {
+    $env:VCPKG_DEFAULT_TRIPLET = "x64-linux"
+} else {
+    throw 'Unsupported platform.'
 }
 
 # Get our dependencies using vcpkg!
@@ -47,8 +49,31 @@ if ($IsWindows) {
     $vcpkgexec = "vcpkg"
 }
 
+# Create overlay triplet directory
+$env:VCPKG_OVERLAY_TRIPLETS = "$env:GITHUB_WORKSPACE/vcpkg-overlay-triplets"
+New-Item -ItemType Directory -Path $env:VCPKG_OVERLAY_TRIPLETS -Force
+
+# Customizes a triplet by starting with the built-in one and appending extra commands
+function WriteOverlayTriplet() {
+    $srcPath = "$env:VCPKG_ROOT/triplets/$env:VCPKG_DEFAULT_TRIPLET.cmake"
+    $dstPath = "$env:VCPKG_OVERLAY_TRIPLETS/$env:VCPKG_DEFAULT_TRIPLET.cmake"
+    Copy-Item -Path $srcPath -Destination $dstPath
+
+    function AppendLine($value) {
+        Add-Content -Path $dstPath -Value $value
+    }
+
+    # Ensure trailing newline is present
+    AppendLine ''
+
+    # Skip debug builds
+    AppendLine 'set(VCPKG_BUILD_TYPE release)'
+}
+
 # This function will be called for each triplet being built
 function InstallPackages() {
+    WriteOverlayTriplet
+
     # libheif: Skip x265 on arm64-windows as it doesn't build (only needed for encoding)
     $libheif = $env:VCPKG_DEFAULT_TRIPLET -eq 'arm64-windows' ? 'libheif[core]' : 'libheif'
 

--- a/pwsh/get-vcpkg-deps.ps1
+++ b/pwsh/get-vcpkg-deps.ps1
@@ -68,6 +68,12 @@ function WriteOverlayTriplet() {
 
     # Skip debug builds
     AppendLine 'set(VCPKG_BUILD_TYPE release)'
+
+    if ($IsWindows) {
+        # Workaround for https://developercommunity.visualstudio.com/t/10664660
+        AppendLine 'string(APPEND VCPKG_CXX_FLAGS " -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")'
+        AppendLine 'string(APPEND VCPKG_C_FLAGS " -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")'
+    }
 }
 
 # This function will be called for each triplet being built


### PR DESCRIPTION
In the VS2022 17.10 compiler, Microsoft turned on a feature by default that broke backwards compatibility with older Visual C++ runtimes:

<img width="880" alt="Screenshot 2024-07-01 at 7 03 57 PM" src="https://github.com/jurplel/kimageformats-binaries/assets/6741660/2b10ad40-dfc1-4cee-a138-4c70995f8a7f">

Support for this in the runtime was added a few versions back in VS2022 17.8, corresponding to the Visual C++ Runtime 14.38 version, but on the compiler side, the new constexpr constructor was initially opt-in. Then in the 17.10 compiler, it was made opt-out, i.e. on by default.

Unfortunately this means that if users have the Visual C++ Runtime < 14.38 installed, it can result in crashing with no clear indication to the user as to why. At least if the runtime isn't installed, they see a message box about missing MSVCP140.dll, but in this case, an older runtime will result in the application silently exiting and the only indication of a problem being in the Windows Event Log with an access violation for MSVCP140.dll.

Microsoft [insists this is "by design"](https://developercommunity.visualstudio.com/t/10664660), and sure, ideally all users should install the latest Visual C++ Runtime. But as a user, stuff like this is easy to overlook, so in the interest of reducing support headaches, it's probably best to opt-out of this at least until the new runtime is more prevalent in the wild.

So far I've only noticed the effects of an outdated runtime in 2 places: 1) when attempting to load .jxl files, qView will crash/exit, and 2) the HEIF plugin doesn't load properly, so .heic files can't open and display the unsupported format error.

Setting `$env:CXXFLAGS`/`$env:CFLAGS` should take care of any places where we run CMake directly (e.g. KImageFormats/KArchive), but it didn't seem to resolve the JXL/HEIF problem for me, so I guess CMake via vcpkg doesn't respect those environment variables. Hence the need for custom (overlay) triplets. A bit unfortunate to have to do all that, but the ability to do overlay triplets can come in handy for other things. Which leads to the bonus in this PR: it now skips the vcpkg debug builds, saving a bit of time/computing resources during compilation.