### PR TITLE
Qt 6.7.3 and other updates

### DIFF
--- a/.github/workflows/QtApng.yml
+++ b/.github/workflows/QtApng.yml
@@ -21,14 +21,14 @@ jobs:
             arch: 'win32_msvc2019'
             buildArch: 'X86'
           - os: windows-2022
-            vers: '6.5.3'
+            vers: '6.7.3'
             arch: 'win64_msvc2019_64'
           - os: windows-2022
-            vers: '6.5.3'
+            vers: '6.7.3'
             arch: 'win64_msvc2019_arm64'
             buildArch: 'Arm64'
           - os: macos-12
-            vers: '6.5.3'
+            vers: '6.7.3'
             buildArch: 'Universal'
 
     steps:

--- a/.github/workflows/QtApng.yml
+++ b/.github/workflows/QtApng.yml
@@ -21,12 +21,6 @@ jobs:
             arch: 'win32_msvc2019'
             buildArch: 'X86'
           - os: windows-2022
-            vers: '6.2.2'
-            arch: 'win64_msvc2019_64'
-          - os: macos-12
-            vers: '6.2.2'
-            buildArch: 'Universal'
-          - os: windows-2022
             vers: '6.5.3'
             arch: 'win64_msvc2019_64'
           - os: windows-2022

--- a/.github/workflows/QtApng.yml
+++ b/.github/workflows/QtApng.yml
@@ -14,7 +14,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             vers: '5.15.2'
-          - os: macos-12
+          - os: macos-13
             vers: '5.15.2'
           - os: windows-2022
             vers: '5.15.2'
@@ -27,7 +27,7 @@ jobs:
             vers: '6.7.3'
             arch: 'win64_msvc2019_arm64'
             buildArch: 'Arm64'
-          - os: macos-12
+          - os: macos-14
             vers: '6.7.3'
             buildArch: 'Universal'
 

--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -21,14 +21,14 @@ jobs:
             arch: 'win32_msvc2019'
             buildArch: 'X86'
           - os: windows-2022
-            vers: '6.5.3'
+            vers: '6.7.3'
             arch: 'win64_msvc2019_64'
           - os: windows-2022
-            vers: '6.5.3'
+            vers: '6.7.3'
             arch: 'win64_msvc2019_arm64'
             buildArch: 'Arm64'
           - os: macos-12
-            vers: '6.5.3'
+            vers: '6.7.3'
             buildArch: 'Universal'
 
     steps:

--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: '7eb700c9688daed6d8bdcdc571ebe3eedea6a774'
+          vcpkgGitCommitId: '9558037875497b9db8cf38fcd7db68ec661bffe7'
 
       - name: Build KImageFormats (just one big step for now)
         run: pwsh pwsh/buildkimageformats.ps1

--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -21,12 +21,6 @@ jobs:
             arch: 'win32_msvc2019'
             buildArch: 'X86'
           - os: windows-2022
-            vers: '6.2.2'
-            arch: 'win64_msvc2019_64'
-          - os: macos-12
-            vers: '6.2.2'
-            buildArch: 'Universal'
-          - os: windows-2022
             vers: '6.5.3'
             arch: 'win64_msvc2019_64'
           - os: windows-2022

--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -14,7 +14,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             vers: '5.15.2'
-          - os: macos-12
+          - os: macos-13
             vers: '5.15.2'
           - os: windows-2022
             vers: '5.15.2'
@@ -27,7 +27,7 @@ jobs:
             vers: '6.7.3'
             arch: 'win64_msvc2019_arm64'
             buildArch: 'Arm64'
-          - os: macos-12
+          - os: macos-14
             vers: '6.7.3'
             buildArch: 'Universal'
 

--- a/pwsh/buildecm.ps1
+++ b/pwsh/buildecm.ps1
@@ -10,12 +10,10 @@ if ($IsWindows) {
     & "$env:GITHUB_WORKSPACE/pwsh/vcvars.ps1"
 }
 
+$argDeviceArchs = $IsMacOS -and $env:buildArch -eq 'Universal' ? '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64' : $null
+
 # Build
-if ($IsMacOS -and $env:buildArch -eq 'Universal') {
-    cmake -G Ninja . -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
-} else {
-    cmake -G Ninja .
-}
+cmake -G Ninja . $argDeviceArchs
 
 if ($IsWindows) {
     ninja install

--- a/pwsh/get-vcpkg-deps.ps1
+++ b/pwsh/get-vcpkg-deps.ps1
@@ -90,10 +90,7 @@ function WriteOverlayTriplet() {
 function InstallPackages() {
     WriteOverlayTriplet
 
-    # libheif: Skip x265 on arm64-windows as it doesn't build (only needed for encoding)
-    $libheif = $env:VCPKG_DEFAULT_TRIPLET -eq 'arm64-windows' ? 'libheif[core]' : 'libheif'
-
-    & "$env:VCPKG_ROOT/$vcpkgexec" install libjxl libavif[aom] $libheif openexr zlib libraw
+    & "$env:VCPKG_ROOT/$vcpkgexec" install libjxl libavif[aom] libheif openexr zlib libraw
 }
 
 # Build for main triplet

--- a/pwsh/get-vcpkg-deps.ps1
+++ b/pwsh/get-vcpkg-deps.ps1
@@ -1,5 +1,7 @@
 #!/usr/bin/env pwsh
 
+using namespace System.Runtime.InteropServices
+
 # Install vcpkg if we don't already have it
 if ($env:VCPKG_ROOT -eq $null) {
   git clone https://github.com/microsoft/vcpkg
@@ -19,27 +21,35 @@ if ($IsWindows) {
     choco install nasm
 } elseif ($IsMacOS) {
     brew install nasm
-# Remove this package on macOS because it caues problems
-    brew uninstall --ignore-dependencies webp # Avoid linking to homebrew stuff later
 } else {
     # (and bonus dependencies)
     sudo apt-get install nasm libxi-dev libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev
 }
 
 # Set default triplet
+$hostArch = [RuntimeInformation]::OSArchitecture
 if ($IsWindows) {
-    # Use environment variable to detect target platform
     $env:VCPKG_DEFAULT_TRIPLET =
         $env:buildArch -eq 'X86' ? 'x86-windows' :
         $env:buildArch -eq 'Arm64' ? 'arm64-windows' :
-        'x64-windows'
+        $hostArch -eq [Architecture]::X64 ? 'x64-windows' :
+        $null
 } elseif ($IsMacOS) {
-    # Build x64 first; arm64 will come later for universal binaries
-    $env:VCPKG_DEFAULT_TRIPLET = "x64-osx"
+    # For universal binaries, build x64 first; arm64 will come later
+    $env:VCPKG_DEFAULT_TRIPLET =
+        $env:buildArch -eq 'Universal' ? 'x64-osx' :
+        $hostArch -eq [Architecture]::X64 ? 'x64-osx' :
+        $hostArch -eq [Architecture]::Arm64 ? 'arm64-osx' :
+        $null
 } elseif ($IsLinux) {
-    $env:VCPKG_DEFAULT_TRIPLET = "x64-linux"
+    $env:VCPKG_DEFAULT_TRIPLET =
+        $hostArch -eq [Architecture]::X64 ? 'x64-linux' :
+        $null
 } else {
     throw 'Unsupported platform.'
+}
+if (-not $env:VCPKG_DEFAULT_TRIPLET) {
+    throw 'Unsupported architecture.'
 }
 
 # Get our dependencies using vcpkg!

--- a/util/kimageformats-find-libraw-vcpkg.patch
+++ b/util/kimageformats-find-libraw-vcpkg.patch
@@ -1,20 +1,17 @@
---- kimageformats/CMakeLists.txt	2023-08-05 16:14:58
-+++ CMakeLists.txt	2023-08-05 16:14:49
-@@ -74,11 +74,15 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -74,11 +74,13 @@
  add_feature_info(LibJXL LibJXL_FOUND "required for the QImage plugin for JPEG XL images")
  
  # note: module FindLibRaw missing from https://invent.kde.org/frameworks/extra-cmake-modules
 -find_package(LibRaw 0.20.2)
--set_package_properties(LibRaw PROPERTIES
-+find_package(libraw CONFIG)
-+get_property(importTargetsAfter DIRECTORY "${CMAKE_SOURCE_DIR}" PROPERTY IMPORTED_TARGETS)
-+set_package_properties(libraw PROPERTIES
++find_package(LibRaw 0.20.2 NAMES libraw)
+ set_package_properties(LibRaw PROPERTIES
      TYPE OPTIONAL
      PURPOSE "Required for the QImage plugin for RAW images"
  )
 +# Adapt naming so the rest of the cmake infra finds this new target
 +add_library(LibRaw::LibRaw ALIAS libraw::raw)
-+set(LibRaw_FOUND ${libraw_FOUND})
  
  ecm_set_disabled_deprecation_versions(
      QT 5.15.2


### PR DESCRIPTION
* Update Qt to 6.7.3.
* Update macOS runners since macos-12 will be [retired soon](https://github.com/actions/runner-images/issues/10721). Due to the need for the Qt 5 build to stay on Xcode 14, it will go on the macos-13 runner since the macos-14 runner [won't support that](https://github.com/actions/runner-images/issues/10703) soon. If you're wondering why I didn't add a workaround [like this](https://github.com/jurplel/install-qt-action/commit/9a9ddab2c1d7d508339827df92578a15aa129f85) to avoid Xcode 15.0.x on the macos-14 runner, it's because the runner images have been updated since then and Xcode 15.4 is now the default on macos-14.
* Update vcpkgGitCommitId, eliminates the need to skip the libheif workaround (i.e. build w/o x265) on Windows ARM.
* Cleaned up the LibRaw patch based on [this comment](https://github.com/microsoft/vcpkg/issues/32967#issuecomment-1666716308).