### PR TITLE
macOS/Qt5: Fix HEIF

### DIFF
--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  VCPKG_BINARY_SOURCES: 'clear;default,readwrite'
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/pwsh/get-vcpkg-deps.ps1
+++ b/pwsh/get-vcpkg-deps.ps1
@@ -21,6 +21,9 @@ if ($IsWindows) {
     choco install nasm
 } elseif ($IsMacOS) {
     brew install nasm
+    # Uninstall this because it can result in a non-working heif plugin,
+    # but it might not be present, so silence stderr
+    brew uninstall --ignore-dependencies webp 2>$null
 } else {
     # (and bonus dependencies)
     sudo apt-get install nasm libxi-dev libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev


### PR DESCRIPTION
Small fix for a regression introduced by last PR: HEIF wasn't working in the legacy Qt 5 macOS build. A few `brew uninstall` commands were removed because they resulted in `Error: No such keg` on the newer macOS runners. `zlib` doesn't seem to be present on 13 or 14 anymore. But I failed to notice `webp` is only not present on 14, and still existing on 13. It didn't even cause any build errors, it just somehow(?!) resulted in the HEIF plugin being non-functional.