### PR TITLE
macOS/Qt5: Fix KRA/ORA

### DIFF
--- a/pwsh/buildkimageformats.ps1
+++ b/pwsh/buildkimageformats.ps1
@@ -121,12 +121,14 @@ if ($IsMacOS -and $env:buildArch -eq 'Universal') {
 
 # Fix linking on macOS
 if ($IsMacOS) {
-    install_name_tool -change /Users/runner/work/kimageformats-binaries/kimageformats-binaries/kimageformats/karchive/installed//libKF5Archive.5.dylib @rpath/libKF5Archive.5.dylib output/kimg_kra.so
-    install_name_tool -change /Users/runner/work/kimageformats-binaries/kimageformats-binaries/kimageformats/karchive/installed//libKF5Archive.5.dylib @rpath/libKF5Archive.5.dylib output/kimg_ora.so
+    $libDirName = $qtVersion.Major -eq 5 ? 'lib' : '' # empty name results in double slash in path which is intentional
+
+    install_name_tool -change "$(Get-Location)/karchive/installed/$libDirName/libKF5Archive.5.dylib" @rpath/libKF5Archive.5.dylib output/kimg_kra.so
+    install_name_tool -change "$(Get-Location)/karchive/installed/$libDirName/libKF5Archive.5.dylib" @rpath/libKF5Archive.5.dylib output/kimg_ora.so
 
     if ($IsMacOS -and $env:buildArch -eq 'Universal') {
-        install_name_tool -change /Users/runner/work/kimageformats-binaries/kimageformats-binaries/kimageformats/karchive/installed_arm64//libKF5Archive.5.dylib @rpath/libKF5Archive.5.dylib output/kimg_kra.so
-        install_name_tool -change /Users/runner/work/kimageformats-binaries/kimageformats-binaries/kimageformats/karchive/installed_arm64//libKF5Archive.5.dylib @rpath/libKF5Archive.5.dylib output/kimg_ora.so
+        install_name_tool -change "$(Get-Location)/karchive/installed_arm64/$libDirName/libKF5Archive.5.dylib" @rpath/libKF5Archive.5.dylib output/kimg_kra.so
+        install_name_tool -change "$(Get-Location)/karchive/installed_arm64/$libDirName/libKF5Archive.5.dylib" @rpath/libKF5Archive.5.dylib output/kimg_ora.so
     }
 }
 


### PR DESCRIPTION
This time thankfully not a regression; I don't believe this has ever worked. The "install name" for KArchive is different depending on whether we built with Qt5 or Qt6, so the `install_name_tool` command was only able to find/change the specified name in the Qt6 builds. This resulted in the legacy macOS qView being unable to load KRA/ORA files. I ran this fix through my Actions pipeline and can verify the names are correct in both cases now, e.g.:
```
otool -l kimg_kra-qt5.so | grep Archive
         name @rpath/libKF5Archive.5.dylib (offset 24)
```
```
otool -l kimg_kra-qt6.so | grep Archive
         name @rpath/libKF5Archive.5.dylib (offset 24)
         name @rpath/libKF5Archive.5.dylib (offset 24)
```
(Universal binary hence the two names in the Qt6 build).

By the way, [this is a little test suite of images](https://github.com/jdpurcell/kimageformats-binaries/releases/download/cont/TestImages.zip) I gathered to test a lot (but not all) of the KImageFormats decoders. There's only one file in there you won't be able to open (.pxr) since the decoder is only in KDE Frameworks 6 (I updated my fork to that a while back; can PR eventually but probably not worth focusing on right now).