### PR TITLE
Keep OpenEXR on version that's compatible with KImageFormats

### DIFF
--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: '9558037875497b9db8cf38fcd7db68ec661bffe7'
+          vcpkgGitCommitId: '4fcf123fe53c63db265b5841a5aeff06cec375a1'
 
       - name: Build KImageFormats (just one big step for now)
         run: pwsh pwsh/buildkimageformats.ps1

--- a/pwsh/buildkimageformats.ps1
+++ b/pwsh/buildkimageformats.ps1
@@ -42,7 +42,7 @@ if ($IsWindows) {
 
 
 & "$env:GITHUB_WORKSPACE/pwsh/buildecm.ps1" $kde_vers
-& "$env:GITHUB_WORKSPACE/pwsh/get-vcpkg-deps.ps1"
+& "$env:GITHUB_WORKSPACE/pwsh/get-vcpkg-deps.ps1" $kde_vers
 & "$env:GITHUB_WORKSPACE/pwsh/buildkarchive.ps1" $kde_vers
 
 # Resolve pthread error on linux

--- a/util/overlay-openexr-3.2.4/portfile.cmake
+++ b/util/overlay-openexr-3.2.4/portfile.cmake
@@ -1,0 +1,58 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO AcademySoftwareFoundation/openexr
+    REF "v${VERSION}"
+    SHA512 ecc3d8b206bda5e5897ac9cd797a8432b76981de10d49cbb107af2b4108c22186de0dda25a9a43b07e18d641ef71508445d95f659a4ca932e029d48ee029a492
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
+    FEATURES
+        tools   OPENEXR_BUILD_TOOLS
+        tools   OPENEXR_INSTALL_TOOLS
+)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${OPTIONS}
+        -DBUILD_TESTING=OFF
+        -DBUILD_WEBSITE=OFF
+        -DCMAKE_REQUIRE_FIND_PACKAGE_libdeflate=ON
+        -DOPENEXR_BUILD_EXAMPLES=OFF
+        -DOPENEXR_INSTALL_PKG_CONFIG=ON
+    OPTIONS_DEBUG
+        -DOPENEXR_BUILD_TOOLS=OFF
+        -DOPENEXR_INSTALL_TOOLS=OFF
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/OpenEXR)
+
+vcpkg_fixup_pkgconfig()
+
+if(OPENEXR_INSTALL_TOOLS)
+    vcpkg_copy_tools(
+        TOOL_NAMES
+            exr2aces
+            # not installed: exrcheck
+            exrenvmap
+            exrheader
+            exrinfo
+            exrmakepreview
+            exrmaketiled
+            exrmanifest
+            exrmultipart
+            exrmultiview
+            exrstdattr
+        AUTO_CLEAN
+    )
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/util/overlay-openexr-3.2.4/usage
+++ b/util/overlay-openexr-3.2.4/usage
@@ -1,0 +1,4 @@
+openexr provides CMake targets:
+
+    find_package(OpenEXR CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE OpenEXR::OpenEXR)

--- a/util/overlay-openexr-3.2.4/vcpkg.json
+++ b/util/overlay-openexr-3.2.4/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "openexr",
+  "version": "3.2.4",
+  "description": "OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications",
+  "homepage": "https://www.openexr.com/",
+  "license": "BSD-3-Clause",
+  "supports": "!uwp",
+  "dependencies": [
+    "imath",
+    "libdeflate",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tools": {
+      "description": "Build tools"
+    }
+  }
+}


### PR DESCRIPTION
OpenEXR 3.3 introduced a change that broke compatibility with KImageFormats. It was [fixed](https://invent.kde.org/frameworks/kimageformats/-/commit/7d696a81d2bda42e118bdd464757541a4464bd47) in KImageFormats 6.8, but even if you updated to that, you still need to keep KImageFormats 5.x compatibility for the Qt5 builds. This PR uses the overlay port capability in vcpkg to override the files for the OpenEXR port, keeping it on 3.2.4 regardless of the vcpkg commit ID in use. The port files I added in the `util` folder were taken from [here](https://github.com/microsoft/vcpkg/tree/a0aa27dc047bb27d16ff206c12c90750b5796c9d/ports/openexr), which is the last commit to update the port before it went to 3.3. The other way to request a specific version of a port from vcpkg is a [bit more involved](https://github.com/jdpurcell/kimageformats-binaries/commit/e03e996d1b5f7404568d9ac90c7a931b6b17cf00), so I thought you would appreciate this simpler workaround for now.

I already ran this through my Actions workflow and produced qView builds for Windows/macOS to test it, and all 5 of them (macOS Universal/x64, Windows x64/ARM64/x86) are able to load my test suite of images without regression. The only update that's needed on the qView side is to change the filename in the Windows plugin copying from `lcms2.dll` to `lcms2-2.dll` (I will PR that), which changed after an update because I bumped the `vcpkgCommitId` here too. vcpkg finally updated the AOM port today, by the way, so the x86 Windows build is back to completing in about ~15 minutes. 🎉