### PR TITLE
Fix warning when used with macdeployqt

### DIFF
--- a/pwsh/buildkimageformats.ps1
+++ b/pwsh/buildkimageformats.ps1
@@ -128,6 +128,8 @@ if ($IsMacOS) {
     $karchLibName = "libKF${kfMajorVer}Archive.$kfMajorVer"
     $libDirName = $kfMajorVer -le 5 -and $qtVersion.Major -ge 6 ? '' : 'lib' # empty name results in double slash in path which is intentional
 
+    install_name_tool -id "@rpath/$karchLibName.dylib" "$prefix_out/$karchLibName.dylib"
+
     install_name_tool -change "$(Get-Location)/karchive/installed/$libDirName/$karchLibName.dylib" "@rpath/$karchLibName.dylib" "$prefix_out/kimg_kra$kimgLibExt"
     install_name_tool -change "$(Get-Location)/karchive/installed/$libDirName/$karchLibName.dylib" "@rpath/$karchLibName.dylib" "$prefix_out/kimg_ora$kimgLibExt"
 


### PR DESCRIPTION
In the "Deploy qView" step [here](https://github.com/jurplel/qView/actions/runs/13310118828/job/37170273558), I noticed the problem:

`ERROR: no file at "/Users/runner/work/kimageformats-binaries/kimageformats-binaries/kimageformats/karchive/installed_arm64/lib/libKF6Archive.6.dylib"`

Seems more like a warning than an error as the job still completes and the resulting build can load ORA/KRA files fine, but nonetheless we can fix it.

Before this fix:

```text
otool -D libKF6Archive.6.dylib
libKF6Archive.6.dylib (architecture x86_64):
/Users/runner/work/kimageformats-binaries/kimageformats-binaries/kimageformats/karchive/installed/lib/libKF6Archive.6.dylib
libKF6Archive.6.dylib (architecture arm64):
/Users/runner/work/kimageformats-binaries/kimageformats-binaries/kimageformats/karchive/installed_arm64/lib/libKF6Archive.6.dylib
```

After:

```text
otool -D libKF6Archive.6.dylib
libKF6Archive.6.dylib (architecture x86_64):
@rpath/libKF6Archive.6.dylib
libKF6Archive.6.dylib (architecture arm64):
@rpath/libKF6Archive.6.dylib
```