### PR TITLE
Windows: Remove unused DLLs from artifacts

### DIFF
--- a/pwsh/buildkimageformats.ps1
+++ b/pwsh/buildkimageformats.ps1
@@ -149,5 +149,16 @@ if ($IsLinux) {
 
 if ($IsWindows) {
     Write-Host "`nDetecting plugin dependencies..."
-    & "$env:GITHUB_WORKSPACE/pwsh/scankimgdeps.ps1" $prefix_out
+    $kimgDeps = & "$env:GITHUB_WORKSPACE/pwsh/scankimgdeps.ps1" $prefix_out
+
+    # Remove unnecessary files
+    $files = Get-ChildItem $prefix_out
+    foreach ($file in $files) {
+        $name = $file.Name
+        $found = $name -like 'kimg_*.dll' -or $name -in $kimgDeps
+        if (-not $found) {
+            Write-Host "Deleting $name"
+            Remove-Item -Path $file.FullName
+        }
+    }
 }

--- a/pwsh/scankimgdeps.ps1
+++ b/pwsh/scankimgdeps.ps1
@@ -47,6 +47,8 @@ function GetNestedDeps($dllPath) {
     return $visited | Where-Object { $_ -ne $dllPath } | ForEach-Object { Split-Path $_ -Leaf } | Sort-Object
 }
 
+$allDeps = [System.Collections.Generic.HashSet[string]]::new()
+
 # Loop through DLL files starting with "kimg_" in the specified directory in alphabetical order
 Get-ChildItem -Path $dir -Filter "kimg_*.dll" |
     Sort-Object Name |
@@ -56,8 +58,11 @@ Get-ChildItem -Path $dir -Filter "kimg_*.dll" |
         
         # Check if any dependencies were found and output appropriately
         if ($deps.Count -gt 0) {
-            # Joining dependency names to pass as an array
-            $depList = $deps -join '", "'
-            Write-Output "$dllName`: `"$depList`""
+            # Append to the set of all dependencies
+            $deps | ForEach-Object { [void]$allDeps.Add($_) }
+            # Display this file's dependencies
+            Write-Information "$dllName`: `"$($deps -join '", "')`"" -InformationAction Continue
         }
     }
+
+return $allDeps | Sort-Object


### PR DESCRIPTION
#10 already made the macOS/Linux builds more selective about what gets copied to the output directory (via lines 120/122 in [buildkimageformats.ps1](https://github.com/jurplel/kimageformats-binaries/commit/b3974b087a554eb620e355eccb3fbd04f2bec907#diff-c64927b5df5c04e84931c2f20f79501657f014f0c784b1fa45919aa1bba47956R120)), so now there's only one copy of the KArchive binary, and the Linux artifacts used to contain some `*test` files too:

<img width="411" alt="image" src="https://github.com/user-attachments/assets/c5d4dcf5-a800-4b1e-9f15-bb6f56ac4f03" />

vs:
<img width="407" alt="image" src="https://github.com/user-attachments/assets/2a7d1614-1218-412a-bad8-d20f27513f83" />

This leaves only the Windows build including some unnecessary DLLs in the artifacts, such as ~a duplicate copy~ [another variant](https://github.com/jurplel/kimageformats-binaries/pull/13) of LibRaw, and some like `turbojpeg.dll` which are somehow unreferenced:
<img width="403" alt="image" src="https://github.com/user-attachments/assets/5ada8440-6f39-4ec3-abc5-e49796764638" />

This PR uses the output of the `scankimgdeps.ps1` script to locate and remove unreferenced DLLs so they don't get included in the artifacts. This can [greatly simplify](https://github.com/jdpurcell/qView/commit/eebace8be56afd7e85551881cbf58479d1b1bc67) plugin deployment especially on Windows, since now all you need to do is move `kimg_*` to the `imageformats` directory, and everything remaining can be assumed a useful/necessary dependency.