### PR TITLE
Use thread-safe version of LibRaw

### DIFF
--- a/pwsh/buildkimageformats.ps1
+++ b/pwsh/buildkimageformats.ps1
@@ -18,10 +18,10 @@ git clone https://invent.kde.org/frameworks/kimageformats.git
 cd kimageformats
 git checkout $kfGitRef
 
-# Apply patch to cmake file for vcpkg libraw
-if (-Not $IsWindows) {
-    patch CMakeLists.txt "../util/kimageformats$kfMajorVer-find-libraw-vcpkg.patch"
-}
+# Patch CMakeLists to work with vcpkg's libraw, bypassing KImageFormats' FindLibRaw.cmake
+# module. The patch also specifies the thread-safe version of libraw.
+patch CMakeLists.txt "../util/kimageformats$kfMajorVer-find-libraw-vcpkg.patch"
+rm "cmake/find-modules/FindLibRaw.cmake"
 
 
 # dependencies

--- a/util/kimageformats5-find-libraw-vcpkg.patch
+++ b/util/kimageformats5-find-libraw-vcpkg.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -74,11 +74,13 @@
+@@ -74,11 +74,12 @@
  add_feature_info(LibJXL LibJXL_FOUND "required for the QImage plugin for JPEG XL images")
  
  # note: module FindLibRaw missing from https://invent.kde.org/frameworks/extra-cmake-modules
@@ -10,8 +10,7 @@
      TYPE OPTIONAL
      PURPOSE "Required for the QImage plugin for RAW images"
  )
-+# Adapt naming so the rest of the cmake infra finds this new target
-+add_library(LibRaw::LibRaw ALIAS libraw::raw)
++add_library(LibRaw::LibRaw ALIAS libraw::raw_r)
  
  ecm_set_disabled_deprecation_versions(
      QT 5.15.2

--- a/util/kimageformats6-find-libraw-vcpkg.patch
+++ b/util/kimageformats6-find-libraw-vcpkg.patch
@@ -1,8 +1,8 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -75,11 +75,13 @@
- endif()
- add_feature_info(LibJXL LibJXL_FOUND "required for the QImage plugin for JPEG XL images")
+@@ -85,11 +85,12 @@
+ add_feature_info(OpenJPEG OpenJPEG_FOUND "required for the QImage plugin for JPEG 2000 images")
+ 
  
 -find_package(LibRaw 0.20.2)
 +find_package(LibRaw 0.20.2 NAMES libraw)
@@ -10,8 +10,7 @@
      TYPE OPTIONAL
      PURPOSE "Required for the QImage plugin for RAW images"
  )
-+# Adapt naming so the rest of the cmake infra finds this new target
-+add_library(LibRaw::LibRaw ALIAS libraw::raw)
++add_library(LibRaw::LibRaw ALIAS libraw::raw_r)
  
+ # JXR plugin disabled by default due to security issues
  option(KIMAGEFORMATS_JXR "Enable plugin for JPEG XR format" OFF)
- if(KIMAGEFORMATS_JXR)


### PR DESCRIPTION
Fixes corrupt-looking images as described in https://github.com/jurplel/qView/issues/742.

KImageFormats' `FindLibRaw.cmake` seems to specifically request the single-threaded version for some reason. That CMake module was only being used for Windows anyway; the CMakeLists.txt patching used by the macOS/Linux builds take over that functionality entirely. So:
1) Use the CMakeLists patching for Windows too so we can keep it all consistent.
2) Update the patching to use `libraw::raw_r` (thread-safe version) instead of `libraw::raw`.

I was kind of surprised that `patch` works on the Windows runners but I believe it's in PATH via Perl that's in the runner images.