### PR TITLE
Qt 6.8.3 / KDE Frameworks 6.14

### DIFF
--- a/.github/workflows/QtApng.yml
+++ b/.github/workflows/QtApng.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
             vers: '5.15.2'
           - os: macos-13
             vers: '5.15.2'
@@ -21,14 +20,14 @@ jobs:
             arch: 'win32_msvc2019'
             buildArch: 'X86'
           - os: windows-2022
-            vers: '6.8.2'
+            vers: '6.8.3'
             arch: 'win64_msvc2022_64'
           - os: windows-2022
-            vers: '6.8.2'
+            vers: '6.8.3'
             arch: 'win64_msvc2022_arm64_cross_compiled'
             buildArch: 'Arm64'
           - os: macos-14
-            vers: '6.8.2'
+            vers: '6.8.3'
             buildArch: 'Universal'
 
     steps:

--- a/.github/workflows/QtApng.yml
+++ b/.github/workflows/QtApng.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - os: ubuntu-22.04
             vers: '5.15.2'
           - os: macos-13
             vers: '5.15.2'

--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: '0d5cae153065957df7f382de7c1549ccc88027e5'
+          vcpkgGitCommitId: '8f54ef5453e7e76ff01e15988bf243e7247c5eb5'
 
       - name: Build KImageFormats (just one big step for now)
         run: pwsh pwsh/buildkimageformats.ps1

--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
             vers: '5.15.2'
           - os: macos-13
             vers: '5.15.2'
@@ -24,14 +23,14 @@ jobs:
             arch: 'win32_msvc2019'
             buildArch: 'X86'
           - os: windows-2022
-            vers: '6.8.2'
+            vers: '6.8.3'
             arch: 'win64_msvc2022_64'
           - os: windows-2022
-            vers: '6.8.2'
+            vers: '6.8.3'
             arch: 'win64_msvc2022_arm64_cross_compiled'
             buildArch: 'Arm64'
           - os: macos-14
-            vers: '6.8.2'
+            vers: '6.8.3'
             buildArch: 'Universal'
 
     steps:
@@ -48,7 +47,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'd504de05dcd7b55df34976be1c824324ec6bca2b'
+          vcpkgGitCommitId: '0d5cae153065957df7f382de7c1549ccc88027e5'
 
       - name: Build KImageFormats (just one big step for now)
         run: pwsh pwsh/buildkimageformats.ps1

--- a/.github/workflows/kimageformats.yml
+++ b/.github/workflows/kimageformats.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - os: ubuntu-22.04
             vers: '5.15.2'
           - os: macos-13
             vers: '5.15.2'

--- a/pwsh/buildkarchive.ps1
+++ b/pwsh/buildkarchive.ps1
@@ -26,7 +26,7 @@ $argQt6 = $qtVersion.Major -eq 6 ? '-DBUILD_WITH_QT6=ON' : $null
 $argDeviceArchs = $IsMacOS -and $env:buildArch -eq 'Universal' ? '-DCMAKE_OSX_ARCHITECTURES=x86_64' : $null
 
 # Build
-cmake -G Ninja -DCMAKE_INSTALL_PREFIX="$PWD/installed/" -DCMAKE_BUILD_TYPE=Release $argQt6 $argDeviceArchs -DWITH_BZIP2=OFF -DWITH_LIBLZMA=OFF -DWITH_LIBZSTD=OFF -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" .
+cmake -G Ninja -DCMAKE_INSTALL_PREFIX="$PWD/installed/" -DCMAKE_BUILD_TYPE=Release $argQt6 $argDeviceArchs -DWITH_BZIP2=OFF -DWITH_LIBLZMA=OFF -DWITH_LIBZSTD=OFF -DWITH_OPENSSL=OFF -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" .
 
 ninja
 ninja install
@@ -38,7 +38,7 @@ if ($IsMacOS -and $env:buildArch -eq 'Universal') {
     rm -rf CMakeFiles/
     rm -rf CMakeCache.txt
 
-    cmake -G Ninja -DCMAKE_INSTALL_PREFIX="$PWD/installed_arm64/" -DCMAKE_BUILD_TYPE=Release $argQt6 -DCMAKE_OSX_ARCHITECTURES="arm64" -DWITH_BZIP2=OFF -DWITH_LIBLZMA=OFF -DWITH_LIBZSTD=OFF -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="arm64-osx" .
+    cmake -G Ninja -DCMAKE_INSTALL_PREFIX="$PWD/installed_arm64/" -DCMAKE_BUILD_TYPE=Release $argQt6 -DCMAKE_OSX_ARCHITECTURES="arm64" -DWITH_BZIP2=OFF -DWITH_LIBLZMA=OFF -DWITH_LIBZSTD=OFF -DWITH_OPENSSL=OFF -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="arm64-osx" .
 
     ninja
     ninja install

--- a/pwsh/buildkimageformats.ps1
+++ b/pwsh/buildkimageformats.ps1
@@ -4,7 +4,7 @@ $qtVersion = [version](qmake -query QT_VERSION)
 Write-Host "Detected Qt Version $qtVersion"
 
 $kfGitRef =
-    $qtVersion -ge [version]'6.6.0' ? 'v6.10.0' :
+    $qtVersion -ge [version]'6.6.0' ? 'v6.13.0' :
     $qtVersion -ge [version]'6.5.0' ? 'v6.8.0' :
     'v5.116.0'
 $kfMajorVer = $kfGitRef -like 'v5.*' ? 5 : 6

--- a/pwsh/buildkimageformats.ps1
+++ b/pwsh/buildkimageformats.ps1
@@ -4,6 +4,7 @@ $qtVersion = [version](qmake -query QT_VERSION)
 Write-Host "Detected Qt Version $qtVersion"
 
 $kfGitRef =
+    $qtVersion -ge [version]'6.7.0' ? 'v6.14.0' :
     $qtVersion -ge [version]'6.6.0' ? 'v6.13.0' :
     $qtVersion -ge [version]'6.5.0' ? 'v6.8.0' :
     'v5.116.0'


### PR DESCRIPTION
* Qt 6.8.3
* KDE Frameworks 6.14
* Bump vcpkg commit
* `ubuntu-22.04` runner to replace retired `ubuntu-20.04`

KArchive started [requiring OpenSSL](https://invent.kde.org/frameworks/karchive/-/commit/af522fdec0b69cae1c8478783ca58debbc8526fe) by default hence `-DWITH_OPENSSL=OFF`. That only makes it optional but on macOS for example it would still link to the one in homebrew; `-DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON` is a nice way to prevent that.